### PR TITLE
Feat: Add predict safe deployment addres flag

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -1,3 +1,3 @@
 package version
 
-var SeerVersion string = "0.2.0"
+var SeerVersion string = "0.2.1"


### PR DESCRIPTION
This PR adds `--safe-predict-address` flag to predict the deployment address with a given salt and contract bytecode.

Example: 

```bash
./ERC20 deploy --keyfile ~/.secret/wallet_keystore.json --rpc https://sepolia.infura.io/v3/YOUR_KEY --symbol KARACURT --decimals 18 --total-supply 1000000000000000 --safe 0xCca527fE0D9bB38b4b24e4F581BD76Fca5baE227 --safe-salt ed87f83fa9f2dc81f36cf8ef271e3c5a443d68c44a239f52aaa3421ef87fc8eb --safe-operation 1 --safe-predict-address
```

```bash
--safe-api not specified, using default ( https://safe-client.safe.global/v1/chains/11155111/transactions/0xCca527fE0D9bB38b4b24e4F581BD76Fca5baE227/propose )
--safe-create-call not specified, using default (0x7cbB62EaA69F79e6873cD1ecB2392971036cFAa4)
Predicting deployment address...
Predicted deployment address: 0x6698A993faFc2d6450F2F852f3F9d0DaAC08B0df
```