### PR TITLE
Optimize g7 testnet parameters.

### DIFF
--- a/cmd.go
+++ b/cmd.go
@@ -296,7 +296,7 @@ func CreateCrawlerCommand() *cobra.Command {
 
 func CreateSynchronizerCommand() *cobra.Command {
 	var startBlock, endBlock, batchSize uint64
-	var timeout, threads int
+	var timeout, threads, cycleTickerWaitTime int
 	var chain, baseDir, customerDbUriFlag string
 
 	synchronizerCmd := &cobra.Command{
@@ -353,7 +353,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 
 			crawler.CurrentBlockchainState.RaiseLatestBlockNumber(latestBlockNumber)
 
-			newSynchronizer.Start(customerDbUriFlag)
+			newSynchronizer.Start(customerDbUriFlag, cycleTickerWaitTime)
 
 			return nil
 		},
@@ -367,6 +367,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 	synchronizerCmd.Flags().Uint64Var(&batchSize, "batch-size", 100, "The number of blocks to crawl in each batch (default: 100)")
 	synchronizerCmd.Flags().StringVar(&customerDbUriFlag, "customer-db-uri", "", "Set customer database URI for development. This workflow bypass fetching customer IDs and its database URL connection strings from mdb-v3-controller API")
 	synchronizerCmd.Flags().IntVar(&threads, "threads", 5, "Number of go-routines for concurrent decoding")
+	synchronizerCmd.Flags().IntVar(&cycleTickerWaitTime, "cycle-ticker-wait-time", 10, "The wait time for the synchronizer in seconds before it try to start new cycle")
 
 	return synchronizerCmd
 }

--- a/deploy/seer-crawler-game7-testnet.service
+++ b/deploy/seer-crawler-game7-testnet.service
@@ -9,7 +9,7 @@ WorkingDirectory=/home/ubuntu/seer
 EnvironmentFile=/home/ubuntu/seer-secrets/app.env
 Restart=on-failure
 RestartSec=15s
-ExecStart=/home/ubuntu/seer/seer crawler --chain game7_testnet --confirmations 0 --threads 2 --proto-time-limit 10 --retry-wait 1000 --retry-multiplier 10
+ExecStart=/home/ubuntu/seer/seer crawler --chain game7_testnet --confirmations 0 --threads 2 --proto-time-limit 10 --retry-wait 1000 --retry-multiplier 1
 SyslogIdentifier=seer-crawler-game7-testnet
 
 [Install]

--- a/deploy/seer-synchronizer-game7-testnet.service
+++ b/deploy/seer-synchronizer-game7-testnet.service
@@ -9,7 +9,7 @@ WorkingDirectory=/home/ubuntu/seer
 EnvironmentFile=/home/ubuntu/seer-secrets/app.env
 Restart=on-failure
 RestartSec=15s
-ExecStart=/home/ubuntu/seer/seer synchronizer --chain game7_testnet
+ExecStart=/home/ubuntu/seer/seer synchronizer --chain game7_testnet --cycle-ticker-wait-time 1
 SyslogIdentifier=seer-synchronizer-game7-testnet
 
 [Install]

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -359,10 +359,10 @@ func (d *Synchronizer) getCustomers(customerDbUriFlag string, customerIds []stri
 	return customerDBConnections, finalCustomerIds, nil
 }
 
-func (d *Synchronizer) Start(customerDbUriFlag string) {
+func (d *Synchronizer) Start(customerDbUriFlag string, cycleTickerWaitTime int) {
 	var isEnd bool
 
-	ticker := time.NewTicker(10 * time.Second)
+	ticker := time.NewTicker(time.Duration(cycleTickerWaitTime) * time.Second)
 	defer ticker.Stop()
 
 	isEnd, err := d.SyncCycle(customerDbUriFlag)


### PR DESCRIPTION
Add new parameter.
`--cycle-ticker-wait-time` - The wait time for the synchronizer in seconds before it try to start new cycle (default 10)