### PR TITLE
Add transactions history to synchronnization synchronization.

### DIFF
--- a/blockchain/arbitrum_one/arbitrum_one.go
+++ b/blockchain/arbitrum_one/arbitrum_one.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch ArbitrumOneBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/arbitrum_sepolia/arbitrum_sepolia.go
+++ b/blockchain/arbitrum_sepolia/arbitrum_sepolia.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch ArbitrumSepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/b3/b3.go
+++ b/blockchain/b3/b3.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch B3BlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/b3_sepolia/b3_sepolia.go
+++ b/blockchain/b3_sepolia/b3_sepolia.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch B3SepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/blockchain.go.tmpl
+++ b/blockchain/blockchain.go.tmpl
@@ -671,19 +671,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch {{.BlockchainName}}BlocksBatch
 
 	dataBytes := rawData.Bytes()
 
     err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
     if err != nil {
-        return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+        return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
     }
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -715,11 +716,33 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+							Hash:                 tx.Hash,
+							BlockHash:            tx.BlockHash,
+							FromAddress:          tx.FromAddress,
+							ToAddress:            tx.ToAddress,
+							Input:                tx.Input,
+							Gas:                  tx.Gas,
+							GasPrice:             tx.GasPrice,
+							Nonce:                tx.Nonce,
+							Value:                tx.Value,
+							MaxFeePerGas:         tx.MaxFeePerGas,
+							MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+							BlockTimestamp:       b.Timestamp,
+							BlockNumber:          b.BlockNumber,
+							TransactionIndex:     tx.TransactionIndex,
+							TransactionType:      tx.TransactionType,
+							{{if .IsSideChain -}} L1BlockNumber: &b.L1BlockNumber, {{end}}
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -874,6 +897,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -889,10 +913,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
     // If any errors occurred, return them
     if len(errorMessages) > 0 {
-        return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+        return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
     }
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/ethereum/ethereum.go
+++ b/blockchain/ethereum/ethereum.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch EthereumBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/game7/game7.go
+++ b/blockchain/game7/game7.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch Game7BlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/game7_orbit_arbitrum_sepolia/game7_orbit_arbitrum_sepolia.go
+++ b/blockchain/game7_orbit_arbitrum_sepolia/game7_orbit_arbitrum_sepolia.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch Game7OrbitArbitrumSepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/game7_testnet/game7_testnet.go
+++ b/blockchain/game7_testnet/game7_testnet.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch Game7TestnetBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/handlers.go
+++ b/blockchain/handlers.go
@@ -137,7 +137,7 @@ type BlockchainClient interface {
 	FetchAsProtoBlocksWithEvents(*big.Int, *big.Int, bool, int) ([]proto.Message, []indexer.BlockIndex, uint64, error)
 	ProcessBlocksToBatch([]proto.Message) (proto.Message, error)
 	DecodeProtoEntireBlockToJson(*bytes.Buffer) (*seer_common.BlocksBatchJson, error)
-	DecodeProtoEntireBlockToLabels(*bytes.Buffer, map[string]map[string]*indexer.AbiEntry, int) ([]indexer.EventLabel, []indexer.TransactionLabel, error)
+	DecodeProtoEntireBlockToLabels(*bytes.Buffer, map[string]map[string]*indexer.AbiEntry, bool, int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error)
 	DecodeProtoTransactionsToLabels([]string, map[uint64]uint64, map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error)
 	ChainType() string
 	GetCode(context.Context, common.Address, uint64) ([]byte, error)

--- a/blockchain/imx_zkevm/imx_zkevm.go
+++ b/blockchain/imx_zkevm/imx_zkevm.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch ImxZkevmBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/imx_zkevm_sepolia/imx_zkevm_sepolia.go
+++ b/blockchain/imx_zkevm_sepolia/imx_zkevm_sepolia.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch ImxZkevmSepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/mantle/mantle.go
+++ b/blockchain/mantle/mantle.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch MantleBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/mantle_sepolia/mantle_sepolia.go
+++ b/blockchain/mantle_sepolia/mantle_sepolia.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch MantleSepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/ronin/ronin.go
+++ b/blockchain/ronin/ronin.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch RoninBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/ronin_saigon/ronin_saigon.go
+++ b/blockchain/ronin_saigon/ronin_saigon.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch RoninSaigonBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/sepolia/sepolia.go
+++ b/blockchain/sepolia/sepolia.go
@@ -658,19 +658,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch SepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -700,11 +701,31 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -859,6 +880,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -874,10 +896,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/xai/xai.go
+++ b/blockchain/xai/xai.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch XaiBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/blockchain/xai_sepolia/xai_sepolia.go
+++ b/blockchain/xai_sepolia/xai_sepolia.go
@@ -668,19 +668,20 @@ func (c *Client) DecodeProtoEntireBlockToJson(rawData *bytes.Buffer) (*seer_comm
 	return blocksBatchJson, nil
 }
 
-func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, error) {
+func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap map[string]map[string]*indexer.AbiEntry, addRawTransactions bool, threads int) ([]indexer.EventLabel, []indexer.TransactionLabel, []indexer.RawTransaction, error) {
 	var protoBlocksBatch XaiSepoliaBlocksBatch
 
 	dataBytes := rawData.Bytes()
 
 	err := proto.Unmarshal(dataBytes, &protoBlocksBatch)
 	if err != nil {
-		return nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
+		return nil, nil, nil, fmt.Errorf("failed to unmarshal data: %v", err)
 	}
 
 	// Shared slices to collect labels
 	var labels []indexer.EventLabel
 	var txLabels []indexer.TransactionLabel
+	var rawTransactions []indexer.RawTransaction
 	var labelsMutex sync.Mutex
 
 	var decodeErr error
@@ -710,11 +711,32 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			// Local slices to collect labels for this block
 			var localEventLabels []indexer.EventLabel
 			var localTxLabels []indexer.TransactionLabel
-
+			var localRawTransactions []indexer.RawTransaction
 			for _, tx := range b.Transactions {
 				var decodedArgsTx map[string]interface{}
 
 				label := indexer.SeerCrawlerLabel
+
+				if addRawTransactions {
+					localRawTransactions = append(localRawTransactions, indexer.RawTransaction{
+						Hash:                 tx.Hash,
+						BlockHash:            tx.BlockHash,
+						FromAddress:          tx.FromAddress,
+						ToAddress:            tx.ToAddress,
+						Input:                tx.Input,
+						Gas:                  tx.Gas,
+						GasPrice:             tx.GasPrice,
+						Nonce:                tx.Nonce,
+						Value:                tx.Value,
+						MaxFeePerGas:         tx.MaxFeePerGas,
+						MaxPriorityFeePerGas: tx.MaxPriorityFeePerGas,
+						BlockTimestamp:       b.Timestamp,
+						BlockNumber:          b.BlockNumber,
+						TransactionIndex:     tx.TransactionIndex,
+						TransactionType:      tx.TransactionType,
+						L1BlockNumber:        &b.L1BlockNumber,
+					})
+				}
 
 				if len(tx.Input) < 10 { // If input is less than 3 characters then it direct transfer
 					continue
@@ -869,6 +891,7 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 			labelsMutex.Lock()
 			labels = append(labels, localEventLabels...)
 			txLabels = append(txLabels, localTxLabels...)
+			rawTransactions = append(rawTransactions, localRawTransactions...)
 			labelsMutex.Unlock()
 		}(b)
 	}
@@ -884,10 +907,10 @@ func (c *Client) DecodeProtoEntireBlockToLabels(rawData *bytes.Buffer, abiMap ma
 
 	// If any errors occurred, return them
 	if len(errorMessages) > 0 {
-		return nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
+		return nil, nil, nil, fmt.Errorf("errors occurred during processing:\n%s", strings.Join(errorMessages, "\n"))
 	}
 
-	return labels, txLabels, nil
+	return labels, txLabels, rawTransactions, nil
 }
 
 func (c *Client) DecodeProtoTransactionsToLabels(transactions []string, blocksCache map[uint64]uint64, abiMap map[string]map[string]*indexer.AbiEntry) ([]indexer.TransactionLabel, error) {

--- a/cmd.go
+++ b/cmd.go
@@ -295,7 +295,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 	var startBlock, endBlock, batchSize uint64
 	var timeout, threads, cycleTickerWaitTime, minBlocksToSync int
 	var chain, baseDir, customerDbUriFlag, rpcUrl string
-
+	var addRawTransactions bool
 	synchronizerCmd := &cobra.Command{
 		Use:   "synchronizer",
 		Short: "Decode the crawled data from various blockchains",
@@ -309,7 +309,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			indexer.InitDBConnection()
 
-			newSynchronizer, synchonizerErr := synchronizer.NewSynchronizer(chain, rpcUrl, baseDir, startBlock, endBlock, batchSize, timeout, threads, minBlocksToSync)
+			newSynchronizer, synchonizerErr := synchronizer.NewSynchronizer(chain, rpcUrl, baseDir, startBlock, endBlock, batchSize, timeout, threads, minBlocksToSync, addRawTransactions)
 			if synchonizerErr != nil {
 				return synchonizerErr
 			}
@@ -342,6 +342,7 @@ func CreateSynchronizerCommand() *cobra.Command {
 	synchronizerCmd.Flags().IntVar(&cycleTickerWaitTime, "cycle-ticker-wait-time", 10, "The wait time for the synchronizer in seconds before it try to start new cycle")
 	synchronizerCmd.Flags().IntVar(&minBlocksToSync, "min-blocks-to-sync", 10, "The minimum number of blocks to sync before the synchronizer starts decoding")
 	synchronizerCmd.Flags().StringVar(&rpcUrl, "rpc-url", "", "The RPC URL to use for the blockchain")
+	synchronizerCmd.Flags().BoolVar(&addRawTransactions, "add-raw-transactions", false, "Set this flag to add raw transactions to the output (default: false)")
 	return synchronizerCmd
 }
 
@@ -962,7 +963,7 @@ func CreateHistoricalSyncCommand() *cobra.Command {
 	var addresses, customerIds []string
 	var startBlock, endBlock, batchSize uint64
 	var timeout, threads, minBlocksToSync int
-	var auto bool
+	var auto, addRawTransactions bool
 
 	historicalSyncCmd := &cobra.Command{
 		Use:   "historical-sync",
@@ -981,7 +982,7 @@ func CreateHistoricalSyncCommand() *cobra.Command {
 
 			indexer.InitDBConnection()
 
-			newSynchronizer, synchonizerErr := synchronizer.NewSynchronizer(chain, rpcUrl, baseDir, startBlock, endBlock, batchSize, timeout, threads, minBlocksToSync)
+			newSynchronizer, synchonizerErr := synchronizer.NewSynchronizer(chain, rpcUrl, baseDir, startBlock, endBlock, batchSize, timeout, threads, minBlocksToSync, addRawTransactions)
 			if synchonizerErr != nil {
 				return synchonizerErr
 			}
@@ -1009,6 +1010,7 @@ func CreateHistoricalSyncCommand() *cobra.Command {
 	historicalSyncCmd.Flags().IntVar(&threads, "threads", 5, "Number of go-routines for concurrent crawling (default: 5)")
 	historicalSyncCmd.Flags().IntVar(&minBlocksToSync, "min-blocks-to-sync", 10, "The minimum number of blocks to sync before the synchronizer starts decoding")
 	historicalSyncCmd.Flags().StringVar(&rpcUrl, "rpc-url", "", "The RPC URL to use for the blockchain")
+	historicalSyncCmd.Flags().BoolVar(&addRawTransactions, "add-raw-transactions", false, "Set this flag to add raw transactions to the output (default: false)")
 
 	return historicalSyncCmd
 }

--- a/indexer/db.go
+++ b/indexer/db.go
@@ -35,7 +35,7 @@ func TransactionsTableName(blockchain string) string {
 	return fmt.Sprintf(blockchain + "_transactions")
 }
 
-func UsersDBTransactionsTableName(blockchain string) string {
+func CustomerDBTransactionsTableName(blockchain string) string {
 	return fmt.Sprintf(blockchain + "_transactions")
 }
 
@@ -826,7 +826,7 @@ func (p *PostgreSQLpgx) EnsureCorrectSelectors(blockchain string, WriteToDB bool
 	return nil
 }
 
-func (p *PostgreSQLpgx) WriteLabes(
+func (p *PostgreSQLpgx) WriteDataToCustomerDB(
 	blockchain string,
 	txCalls []TransactionLabel,
 	events []EventLabel,
@@ -1130,7 +1130,7 @@ func (p *PostgreSQLpgx) WriteTransactions(tx pgx.Tx, blockchain string, transact
 }
 
 func (p *PostgreSQLpgx) WriteRawTransactions(tx pgx.Tx, blockchain string, rawTransactions []RawTransaction) error {
-	tableName := UsersDBTransactionsTableName(blockchain)
+	tableName := CustomerDBTransactionsTableName(blockchain)
 	isBlockchainWithL1Chain := IsBlockchainWithL1Chain(blockchain)
 
 	columns := []string{"hash", "block_hash", "block_timestamp", "block_number",

--- a/indexer/types.go
+++ b/indexer/types.go
@@ -133,3 +133,27 @@ type AbiEntry struct {
 	AbiType string `json:"abi_type"`
 	Once    sync.Once
 }
+
+type RawTransaction struct {
+	// Required fields
+	Hash           string `json:"hash"`
+	BlockHash      string `json:"blockHash"`
+	BlockTimestamp uint64 `json:"block_timestamp"`
+	BlockNumber    uint64 `json:"blockNumber"`
+	FromAddress    string `json:"from"`
+	ToAddress      string `json:"to"`
+	Gas            string `json:"gas"`
+	GasPrice       string `json:"gasPrice"`
+	Input          string `json:"input"`
+	Nonce          string `json:"nonce"`
+	Value          string `json:"value"`
+
+	// Optional fields that might be zero/empty
+	MaxFeePerGas         string `json:"maxFeePerGas,omitempty"`
+	MaxPriorityFeePerGas string `json:"maxPriorityFeePerGas,omitempty"`
+	TransactionIndex     uint64 `json:"transactionIndex"`
+	TransactionType      uint64 `json:"transactionType,omitempty"`
+
+	// Chain-specific optional fields
+	L1BlockNumber *uint64 `json:"l1BlockNumber,omitempty"` // L2 chains only
+}

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -821,7 +821,7 @@ func (d *Synchronizer) processProtoCustomerUpdate(
 	// make retrying
 	retry := 0
 	for {
-		err = customer.Pgx.WriteLabes(d.blockchain, listDecodedTransactions, listDecodedEvents, listDecodedRawTransactions)
+		err = customer.Pgx.WriteDataToCustomerDB(d.blockchain, listDecodedTransactions, listDecodedEvents, listDecodedRawTransactions)
 
 		if err != nil {
 			retry++

--- a/synchronizer/synchronizer.go
+++ b/synchronizer/synchronizer.go
@@ -25,18 +25,19 @@ type Synchronizer struct {
 	Client          seer_blockchain.BlockchainClient
 	StorageInstance storage.Storer
 
-	blockchain      string
-	startBlock      uint64
-	endBlock        uint64
-	batchSize       uint64
-	baseDir         string
-	basePath        string
-	threads         int
-	minBlocksToSync int
+	blockchain         string
+	startBlock         uint64
+	endBlock           uint64
+	batchSize          uint64
+	baseDir            string
+	basePath           string
+	threads            int
+	minBlocksToSync    int
+	addRawTransactions bool
 }
 
 // NewSynchronizer creates a new synchronizer instance with the given blockchain handler.
-func NewSynchronizer(blockchain, rpcUrl, baseDir string, startBlock, endBlock, batchSize uint64, timeout int, threads int, minBlocksToSync int) (*Synchronizer, error) {
+func NewSynchronizer(blockchain, rpcUrl, baseDir string, startBlock, endBlock, batchSize uint64, timeout int, threads int, minBlocksToSync int, addRawTransactions bool) (*Synchronizer, error) {
 	var synchronizer Synchronizer
 
 	basePath := filepath.Join(baseDir, crawler.SeerCrawlerStoragePrefix, "data", blockchain)
@@ -62,14 +63,15 @@ func NewSynchronizer(blockchain, rpcUrl, baseDir string, startBlock, endBlock, b
 		Client:          client,
 		StorageInstance: storageInstance,
 
-		blockchain:      blockchain,
-		startBlock:      startBlock,
-		endBlock:        endBlock,
-		batchSize:       batchSize,
-		baseDir:         baseDir,
-		basePath:        basePath,
-		threads:         threads,
-		minBlocksToSync: minBlocksToSync,
+		blockchain:         blockchain,
+		startBlock:         startBlock,
+		endBlock:           endBlock,
+		batchSize:          batchSize,
+		baseDir:            baseDir,
+		basePath:           basePath,
+		threads:            threads,
+		minBlocksToSync:    minBlocksToSync,
+		addRawTransactions: addRawTransactions,
 	}
 
 	return &synchronizer, nil
@@ -499,7 +501,7 @@ func (d *Synchronizer) SyncCycle(customerDbUriFlag string) (bool, error) {
 		for _, update := range updates {
 			for instanceId := range customerDBConnections[update.CustomerID] {
 				wg.Add(1)
-				go d.processProtoCustomerUpdate(update, rawData, customerDBConnections, instanceId, sem, errChan, &wg)
+				go d.processProtoCustomerUpdate(update, rawData, customerDBConnections, instanceId, sem, errChan, &wg, d.addRawTransactions)
 			}
 		}
 
@@ -718,7 +720,7 @@ func (d *Synchronizer) HistoricalSyncRef(customerDbUriFlag string, addresses []s
 
 			for instanceId := range customerDBConnections[update.CustomerID] {
 				wg.Add(1)
-				go d.processProtoCustomerUpdate(update, rawData, customerDBConnections, instanceId, sem, errChan, &wg)
+				go d.processProtoCustomerUpdate(update, rawData, customerDBConnections, instanceId, sem, errChan, &wg, d.addRawTransactions)
 			}
 
 		}
@@ -772,6 +774,7 @@ func (d *Synchronizer) processProtoCustomerUpdate(
 	sem chan struct{},
 	errChan chan error,
 	wg *sync.WaitGroup,
+	addRawTransactions bool,
 ) {
 	// Decode input raw proto data using ABIs
 	// Write decoded data to the user Database
@@ -801,14 +804,14 @@ func (d *Synchronizer) processProtoCustomerUpdate(
 
 	var listDecodedEvents []indexer.EventLabel
 	var listDecodedTransactions []indexer.TransactionLabel
-
+	var listDecodedRawTransactions []indexer.RawTransaction
 	for _, rawData := range rawDataList {
 		// Decode the raw data to transactions
-		decodedEvents, decodedTransactions, err := d.Client.DecodeProtoEntireBlockToLabels(&rawData, update.Abis, d.threads)
+		decodedEvents, decodedTransactions, decodedRawTransactions, err := d.Client.DecodeProtoEntireBlockToLabels(&rawData, update.Abis, addRawTransactions, d.threads)
 
 		listDecodedEvents = append(listDecodedEvents, decodedEvents...)
 		listDecodedTransactions = append(listDecodedTransactions, decodedTransactions...)
-
+		listDecodedRawTransactions = append(listDecodedRawTransactions, decodedRawTransactions...)
 		if err != nil {
 			errChan <- fmt.Errorf("error decoding data for customer %s: %w", update.CustomerID, err)
 			return
@@ -818,7 +821,7 @@ func (d *Synchronizer) processProtoCustomerUpdate(
 	// make retrying
 	retry := 0
 	for {
-		err = customer.Pgx.WriteLabes(d.blockchain, listDecodedTransactions, listDecodedEvents)
+		err = customer.Pgx.WriteLabes(d.blockchain, listDecodedTransactions, listDecodedEvents, listDecodedRawTransactions)
 
 		if err != nil {
 			retry++


### PR DESCRIPTION
This pull request includes changes to multiple blockchain-related files to add support for returning raw transactions when decoding proto blocks to labels. The most important changes include modifying the `DecodeProtoEntireBlockToLabels` function to accept an additional `addRawTransactions` parameter and updating the function to collect and return raw transactions if the parameter is set to true.

Modifications to `DecodeProtoEntireBlockToLabels` function:

* Added `addRawTransactions` parameter to the function signature and updated the return type to include `[]indexer.RawTransaction`. [[1]](diffhunk://#diff-d3b257422efde7471300aea0f003e1188cc4e48b5fca63e587d961d1568e2df4L671-R684) [[2]](diffhunk://#diff-7ee6b73f5cf65b28bad125c0394a4c70b3d92da2d3fe4365293d383bf515ebb0L671-R684) [[3]](diffhunk://#diff-a8d1461424ebae3808546f67866ae1b1d6f5e734dc49eab602c7b0ce9a1f9a6eL661-R674) [[4]](diffhunk://#diff-2d720e06c676182e4547c44a0167bc549bc7a9712677363fa2c1e60a101fe8a3L661-R674) [[5]](diffhunk://#diff-ab49e64c753010351e2ec4f2076c1d9d95624f6480c03252d2ccf9ba998cdeacL674-R687) [[6]](diffhunk://#diff-277428edfa4d19cf95c48dd071b0c9c229b2cb27fb1d17e260216d493e1661b2L661-R674)
* Updated error handling to return `nil` for the new `rawTransactions` slice in case of errors. [[1]](diffhunk://#diff-d3b257422efde7471300aea0f003e1188cc4e48b5fca63e587d961d1568e2df4L671-R684) [[2]](diffhunk://#diff-7ee6b73f5cf65b28bad125c0394a4c70b3d92da2d3fe4365293d383bf515ebb0L671-R684) [[3]](diffhunk://#diff-a8d1461424ebae3808546f67866ae1b1d6f5e734dc49eab602c7b0ce9a1f9a6eL661-R674) [[4]](diffhunk://#diff-2d720e06c676182e4547c44a0167bc549bc7a9712677363fa2c1e60a101fe8a3L661-R674) [[5]](diffhunk://#diff-ab49e64c753010351e2ec4f2076c1d9d95624f6480c03252d2ccf9ba998cdeacL674-R687) [[6]](diffhunk://#diff-277428edfa4d19cf95c48dd071b0c9c229b2cb27fb1d17e260216d493e1661b2L661-R674)
* Added logic to collect raw transactions if `addRawTransactions` is true. [[1]](diffhunk://#diff-d3b257422efde7471300aea0f003e1188cc4e48b5fca63e587d961d1568e2df4L713-R740) [[2]](diffhunk://#diff-7ee6b73f5cf65b28bad125c0394a4c70b3d92da2d3fe4365293d383bf515ebb0L713-R740) [[3]](diffhunk://#diff-a8d1461424ebae3808546f67866ae1b1d6f5e734dc49eab602c7b0ce9a1f9a6eL703-R729) [[4]](diffhunk://#diff-2d720e06c676182e4547c44a0167bc549bc7a9712677363fa2c1e60a101fe8a3L703-R729) [[5]](diffhunk://#diff-ab49e64c753010351e2ec4f2076c1d9d95624f6480c03252d2ccf9ba998cdeacL718-R746)
* Appended collected raw transactions to the shared slice and returned it. [[1]](diffhunk://#diff-d3b257422efde7471300aea0f003e1188cc4e48b5fca63e587d961d1568e2df4R894) [[2]](diffhunk://#diff-7ee6b73f5cf65b28bad125c0394a4c70b3d92da2d3fe4365293d383bf515ebb0R894) [[3]](diffhunk://#diff-a8d1461424ebae3808546f67866ae1b1d6f5e734dc49eab602c7b0ce9a1f9a6eR883) [[4]](diffhunk://#diff-2d720e06c676182e4547c44a0167bc549bc7a9712677363fa2c1e60a101fe8a3R883) [[5]](diffhunk://#diff-ab49e64c753010351e2ec4f2076c1d9d95624f6480c03252d2ccf9ba998cdeacR900)
* Ensured the function returns the raw transactions along with event and transaction labels. [[1]](diffhunk://#diff-d3b257422efde7471300aea0f003e1188cc4e48b5fca63e587d961d1568e2df4L887-R913) [[2]](diffhunk://#diff-7ee6b73f5cf65b28bad125c0394a4c70b3d92da2d3fe4365293d383bf515ebb0L887-R913) [[3]](diffhunk://#diff-a8d1461424ebae3808546f67866ae1b1d6f5e734dc49eab602c7b0ce9a1f9a6eL877-R902) [[4]](diffhunk://#diff-2d720e06c676182e4547c44a0167bc549bc7a9712677363fa2c1e60a101fe8a3L877-R902) [[5]](diffhunk://#diff-ab49e64c753010351e2ec4f2076c1d9d95624f6480c03252d2ccf9ba998cdeacL892-R919)